### PR TITLE
add microKanren

### DIFF
--- a/example/micro-progs.lurk
+++ b/example/micro-progs.lurk
@@ -1,0 +1,85 @@
+(letrec*
+    (
+
+     (a-and-b
+      (conj
+       (call/fresh (lambda (a) (== a 7)))
+       (call/fresh
+        (lambda (b)
+          (disj
+           (== b 5)
+           (== b 6))))))
+
+     (fives
+      (lambda (x)
+        (disj
+         (== x 5)
+         (lambda (a/c)
+           (lambda ()
+             ((fives x) a/c))))))
+
+     (appendo
+      (lambda (l s out)
+        (disj
+         (conj (== '() l) (== s out))
+         (call/fresh
+          (lambda (a)
+            (call/fresh
+             (lambda (d)
+               (conj
+                (== (cons a d) l)
+                (call/fresh
+                 (lambda (res)
+                   (conj
+                    (== (cons a res) out)
+                    (lambda (s/c)
+                      (lambda ()
+                        ((appendo d s res) s/c))))))))))))))
+
+     (appendo2
+      (lambda (l s out)
+        (disj
+         (conj (== '() l) (== s out))
+         (call/fresh
+          (lambda (a)
+            (call/fresh
+             (lambda (d)
+               (conj
+                (== (cons a d) l)
+                (call/fresh
+                 (lambda (res)
+                   (conj
+                    (lambda (s/c)
+                      (lambda ()
+                        ((appendo2 d s res) s/c)))
+                    (== (cons a res) out))))))))))))
+
+     (call-appendo
+      (call/fresh
+       (lambda (q)
+         (call/fresh
+          (lambda (l)
+            (call/fresh
+             (lambda (s)
+               (call/fresh
+                (lambda (out)
+                  (conj
+                   (appendo l s out)
+                   (== (cons l (cons s (cons out '()))) q)))))))))))
+
+     (call-appendo2
+      (call/fresh
+       (lambda (q)
+         (call/fresh
+          (lambda (l)
+            (call/fresh
+             (lambda (s)
+               (call/fresh
+                (lambda (out)
+                  (conj
+                   (appendo2 l s out)
+                   (== (cons l (cons s (cons out '()))) q)))))))))))
+
+     )
+  (current-env)
+  )

--- a/example/micro-tests.lurk
+++ b/example/micro-tests.lurk
@@ -1,0 +1,11 @@
+(letrec*
+    ((mk1 ((== 5 5) empty-state))
+     (mk2 ((call/fresh (lambda (q) (== q 5))) empty-state))
+     (mk3 (take-all (a-and-b empty-state)))
+     (mk4 (take 1 ((call/fresh (lambda (q) (fives q))) empty-state)))
+     (mk5 (car (((appendo '(a) '(b) '(a b)) empty-state))))
+     (mk6 (car (((appendo2 '(a) '(b) '(a b)) empty-state))))
+     (mk7 (take 2 (call-appendo empty-state)))
+     (mk8 (take 2 (call-appendo2 empty-state)))
+     )
+  (current-env))

--- a/example/micro.lurk
+++ b/example/micro.lurk
@@ -1,0 +1,93 @@
+(letrec*
+    (
+
+     (false
+      nil)
+     (not
+      (lambda (x) (if x nil t)))
+     (nullp
+      not)
+     (pairp
+      (lambda (x) (not (atom x))))
+     (eqv
+      (lambda (x y) (eq x y)))
+
+     (assp
+      (lambda (p l)
+        (if (nullp l) false
+            (if (p (car (car l))) (car l)
+                (assp p (cdr l))))))
+
+     (var
+      (lambda (c) (cons 'var c)))
+     (varp
+      (lambda (x) (if (pairp x) (eq (car x) 'var) nil)))
+     (var=p
+      (lambda (x1 x2) (eqv (cdr x1) (cdr x2))))
+
+     (walk (lambda (u s)
+             (letrec* ((pr (if (varp u) (assp (lambda (v) (var=p u v)) s) nil)))
+               (if pr (walk (cdr pr) s) u))))
+
+     (ext-s (lambda (x v s) (cons (cons x v) s)))
+
+     (mzero '())
+     (unit (lambda (s/c) (cons s/c mzero)))
+
+     (unify
+      (lambda (u1 v1 s)
+        ((lambda (u v)
+           (if (if (varp u) (if (varp v) (var=p u v) nil) nil) s
+               (if (varp u) (ext-s u v s)
+                   (if (varp v) (ext-s v u s)
+                       (if (if (pairp u) (pairp v) nil)
+                           ((lambda (s) (if s (unify (cdr u) (cdr v) s) nil))
+                            (unify (car u) (car v) s))
+                           (if (eqv u v) s nil))))))
+         (walk u1 s) (walk v1 s))))
+
+     (== (lambda (u v)
+           (lambda (s/c)
+             (letrec* ((s (unify u v (car s/c))))
+               (if s (unit (cons s (cdr s/c))) mzero)))))
+
+     (call/fresh (lambda (f)
+                   (lambda (s/c)
+                     (letrec* ((c (cdr s/c)))
+                       ((f (var c)) (cons (car s/c) (+ c 1)))))))
+
+     (mplus
+      (lambda (x1 x2)
+        (if (nullp x1) x2
+            (if (pairp x1) (cons (car x1) (mplus (cdr x1) x2))
+                (lambda () (mplus x2 (x1)))))))
+
+     (bind
+      (lambda (x g)
+        (if (nullp x) mzero
+            (if (pairp x) (mplus (g (car x)) (bind (cdr x) g))
+                (lambda () (bind (x) g))))))
+
+     (disj (lambda (g1 g2) (lambda (s/c) (mplus (g1 s/c) (g2 s/c)))))
+     (conj (lambda (g1 g2) (lambda (s/c) (bind (g1 s/c) g2))))
+
+     (empty-state
+      '((((var dummy))) . 0))
+
+     (pull
+      (lambda (x)
+        (if (if (nullp x) t (pairp x)) x (pull (x)))))
+
+     (take-all
+      (lambda (x)
+        ((lambda (x) (if (nullp x) '() (cons (car x) (take-all (cdr x)))))
+         (pull x))))
+
+     (take
+      (lambda (n x)
+        (if (= n 0) '()
+            ((lambda (x) (if (nullp x) '() (cons (car x) (take (- n 1) (cdr x)))))
+             (pull x)))))
+     )
+  (current-env)
+  )


### PR DESCRIPTION
Two work-arounds:

- The representation for variables is `(var <id>)`. Not ideal in the long term.

- Because of the mixup between nil and #f, the substitution map has a default dummy entry.

```
% make repl
make repl
bin/repl
PACKAGE => #<PACKAGE "LURK.USER">

Lurk REPL.
:help for help.

> :load "example/micro.lurk"
:load "example/micro.lurk"
Reading from example/micro.lurk.

> :load "example/micro-progs.lurk"
:load "example/micro-progs.lurk"
Reading from example/micro-progs.lurk.

> :load "example/micro-tests.lurk"
:load "example/micro-tests.lurk"
Reading from example/micro-tests.lurk.

> mk1
mk1

(((((VAR DUMMY))) . 0))
> mk2
mk2

(((((VAR . 0) . 5) ((VAR DUMMY))) . 1))
>
```