### PR TITLE
Support faster REPL startup (using dumped image).

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,5 +8,12 @@ bin/lurk.image : $(shell find . -type f -name '*.lisp') $(shell find . -type f -
 test : always
 	bin/cl -Q -sp lurk -x "(asdf:test-system \"lurk\")"
 
-repl :
+# Run repl after dumping image if needed.
+# Faster startup than replx, except when dumping a new image.
+repl : image
 	bin/repl
+
+# Run repl after loading Lurk.
+# Slower startup than replx afer image is dumped, but faster for one-off runs.
+replx :
+	bin/replx

--- a/bin/repl
+++ b/bin/repl
@@ -1,5 +1,8 @@
+# Run a REPL, using a saved image.
+# This gives much faster startup but may require dumping an up-to-date image.
+
 if [[ $(which rlwrap) ]]; then
-    rlwrap bin/cl -Q -sp lurk -p lurk.api.tooling -E run-repl
+    rlwrap bin/cl -m bin/lurk.image -Q -sp lurk -p lurk.api.tooling -E run-repl
 else
-    bin/cl -Q -sp lurk -p lurk.api.tooling -E run-repl
+    bin/cl -m bin/lurk.image -Q -sp lurk -p lurk.api.tooling -E run-repl
 fi

--- a/bin/replx
+++ b/bin/replx
@@ -1,0 +1,5 @@
+if [[ $(which rlwrap) ]]; then
+    rlwrap bin/cl -Q -sp lurk -p lurk.api.tooling -E run-repl
+else
+    bin/cl -Q -sp lurk -p lurk.api.tooling -E run-repl
+fi


### PR DESCRIPTION
For general convenience, and especially if we want to start using the REPL for tests, faster startup times would be useful.

This PR changes the `repl` make target to dump an image if necessary, then use that image to run the REPL.

`bin/repl` now uses the most recently built image. The new `bin/replx` (with corresponding `make replx` target) preserves the old behavior (use an unspecialized image and load the project).
