### PR TITLE
Add test and fix discarding env bug.

### DIFF
--- a/bin/lurk
+++ b/bin/lurk
@@ -1,8 +1,10 @@
+DIRNAME=`dirname $0`
+
 # Run a REPL, using a saved image.
 # This gives much faster startup but may require dumping an up-to-date image.
 
 if [[ $(which rlwrap) ]]; then
-    rlwrap bin/cl -m bin/lurk.image -Q -sp lurk -p lurk.tooling.repl -E run-repl -- $@
+    rlwrap $DIRNAME/cl -m bin/lurk.image -Q -sp lurk -p lurk.tooling.repl -E run-repl -- $@
 else
-    bin/cl -m bin/lurk.image -Q -sp lurk -p lurk.tooling.repl -E run-repl -- $@
+    bin/cl -m $DIRNAME/lurk.image -Q -sp lurk -p lurk.tooling.repl -E run-repl -- $@
 fi

--- a/bin/lurkx
+++ b/bin/lurkx
@@ -1,5 +1,7 @@
+DIRNAME=`dirname $0`
+
 if [[ $(which rlwrap) ]]; then
-    rlwrap bin/cl -Q -sp lurk -p lurk.tooling.repl -E run-repl -- $@
+    rlwrap $DIRNAME/cl -Q -sp lurk -p lurk.tooling.repl -E run-repl -- $@
 else
-    bin/cl -Q -sp lurk -p lurk.tooling.repl -E run-repl -- $@
+    $DIRNAME/cl -Q -sp lurk -p lurk.tooling.repl -E run-repl -- $@
 fi

--- a/tooling/example.lisp
+++ b/tooling/example.lisp
@@ -2,24 +2,34 @@
 
 (def-suite* example-suite :in lurk:master-suite)
 
-(defvar *example-tests* (list "test.lurk"
-                              "micro-tests.lurk"
-                              "meta-tests.lurk"
-                              "meta-letrec-tests.lurk"))
+(defparameter *example-tests* (list "test.lurk"
+                                    "micro-tests.lurk"
+                                    "meta-tests.lurk"
+                                    "meta-letrec-tests.lurk"))
 
-(defvar *repl-types-to-test* '(:api
-                               ;; FIXME: Uncomment when :impl tests are passing.
-                               ;; :impl
-                               ))
+(defparameter *repl-types-to-test* '(:api
+                                     ;; FIXME: Uncomment when :impl tests are passing.
+                                     ;; :impl
+                                     ))
+
+(defparameter *project-dir* nil); (make-pathname :directory '(:absolute :home "fil" "lurk")))
 
 (test examples
-  (let* ((bin-dir (merge-pathnames "bin/" (uiop/os:getcwd)))
-         (example-dir (merge-pathnames "example/" (uiop/os:getcwd)))
+  (let* ((root-dir (or *project-dir* (uiop/os:getcwd)))
+         (bin-dir (merge-pathnames "bin/" root-dir))
+         (example-dir (merge-pathnames "example/" root-dir))
          (lurk-bin (merge-pathnames "lurkx" bin-dir)))
     (dolist (test-file *example-tests*)
       (let ((merged (merge-pathnames test-file example-dir)))
         (when (member :api *repl-types-to-test*)
-          (uiop:run-program (format nil "~A ~A --type API" (namestring lurk-bin) merged)))
+          (multiple-value-bind (output error-output exit-code)
+              (uiop:run-program (format nil "~A ~A --type API" (namestring lurk-bin) merged))
+            (when (not (zerop exit-code))
+              (write error-output *error-output*))
+            (is (zerop exit-code))))
         (when (member :impl *repl-types-to-test*)
-          (uiop:run-program (format nil "~A ~A --type IMPL" (namestring lurk-bin) merged))
-          )))))
+          (multiple-value-bind (output error-output exit-code)
+              (uiop:run-program (format nil "~A ~A --type IMPL" (namestring lurk-bin) merged))
+            (when (not (zerop exit-code))
+              (write error-output *error-output*))
+            (is (zerop exit-code))))))))


### PR DESCRIPTION
This adds a test case and fix for the bug described in a discussion ending here: https://github.com/lurk-lang/lurk/issues/14#issuecomment-955119558

NOTE: This fix does cause the `meta-tests.lurk` to fail when run in :IMPL mode. For now, we do not expect those tests to pass, so we should accept the regression there given that we know this fix addresses a real issue.

The other small changes here are to repl testing ergonomics.