### PR TITLE
Add Github CI.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: 'CI'
+
+on:
+  push:
+    branches:
+      - 'main'
+      - 'master'
+  pull_request:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        lisp:
+          - sbcl-bin
+
+    env:
+      LISP: ${{ matrix.lisp }}
+
+    steps:
+      - uses: actions/checkout@v1
+      - uses: 40ants/setup-lisp@v1
+        with:
+          asdf-system: cl-info
+      - uses: 40ants/run-tests@v2
+        with:
+          asdf-system: lurk


### PR DESCRIPTION
Closes #23.

This PR adds CI via a GitHub workflow. I installed https://40ants.com/run-tests/, and it worked ~on the first try~ after I edited it to specify `lurk` as the system to test.

This does 'more' than we need, like install Roswell, but that it also does exactly what we do need with no fuss suggests that it being 'feature-rich' might be a good thing.

In any case, not having CI set up has been an annoyance, so let's not overthink it.

I'm going to push one commit breaking a test to prove to myself that this breaks the CI check. If so, I'll roll that back and we can call it good.