### PR TITLE
Minimal sketch of subset framework.

### DIFF
--- a/api/api.lisp
+++ b/api/api.lisp
@@ -9,6 +9,9 @@
 (defclass subset ()
   ((package :initarg :package :reader subset-package)))
 
+(defmethod print-object ((subset subset) (stream t))
+  (print-unreadable-object (subset stream :type t)))
+
 ;; Not actually implemented yet.
 (defclass min-subset (subset)
   ;; Will need its own package.
@@ -210,9 +213,8 @@
            ((eql api.ram:define)
             (destructuring-bind (var rhs) rest
               (let ((val (eval-expr rhs env)))
-                (values 'defined env (extend-ram-defs ram var val)))))
+                (values 'api.ram:defined env (extend-ram-defs ram var val)))))
            ((eql api.ram:defmacro)
-            (display *package*)
             ;; (defmacro (name param...) body...))
             (let* ((sig (car rest))
                    (body (cdr rest))
@@ -220,7 +222,7 @@
                    (params (cdr sig))
                    (rhs `(api:lambda ,params ,@body)))
               (let ((val (eval-expr rhs env)))
-                (values 'defined env (extend-ram-macros ram var val)))))
+                (values 'api.ram:defined env (extend-ram-macros ram var val)))))
            ((eql api:let)
             (destructuring-bind (bindings &optional body-expr) rest
               (let ((new-env env))
@@ -266,6 +268,7 @@
                     env
                     ram))
            ((eql api:current-env) (values env env ram))
+           ((eql api.ram:current-ram) (values ram env ram))
            (built-in-unary
             (destructuring-bind (arg) rest
               (let ((result (ecase head

--- a/api/package.lisp
+++ b/api/package.lisp
@@ -11,9 +11,10 @@
 (defpackage lurk.api.ram
   (:nicknames :api.ram)
   (:use :common-lisp :lurk.api)
-  (:shadow #:atom #:car #:cdr #:cons #:defmacro #:eq #:if #:lambda #:t #:+ #:- #:* #:/ #:=)
-  (:export #:atom #:car #:cdr #:cons #:current-env #:eq #:define #:defmacro #:if #:lambda #:let #:letrec #:nil #:quote
-           #:t #:+ #:- #:* #:/ #:=))
+  (:shadowing-import-from :lurk.api  #:atom #:car #:cdr #:cons #:defmacro #:eq #:if #:lambda #:t #:+ #:- #:* #:/ #:=)
+  (:export #:atom #:car #:cdr #:cons #:current-env #:current-ram #:eq #:define #:defined #:defmacro #:if #:lambda #:let #:letrec #:nil #:quote
+           #:t #:+ #:- #:* #:/ #:=
+           #:quasi #:uq))
 
 (defpackage lurk.api.impl
   (:nicknames :api.impl)

--- a/tooling/example.lisp
+++ b/tooling/example.lisp
@@ -2,14 +2,14 @@
 
 (def-suite* example-suite :in lurk:master-suite)
 
-(defparameter *example-tests* (list "test.lurk"
-                                    "micro-tests.lurk"
-                                    "meta-tests.lurk"
-                                    "meta-letrec-tests.lurk"
-                                    "../../example/ram-tests.lurk"
-                                    "../../example/macro-tests.lurk"
-                                    "../../example/quasi-tests.lurk"
-                                    "tests/spec.lurk"))
+(defparameter *lurk-tests* '((:core "test.lurk")
+                             (:core "micro-tests.lurk")
+                             (:core "meta-tests.lurk")
+                             (:core "meta-letrec-tests.lurk")
+                             (:core "tests/spec.lurk")
+                             (:ram "../../example/ram-tests.lurk")
+                             (:ram "../../example/macro-tests.lurk")
+                             (:ram "../../example/quasi-tests.lurk")))
 
 (defparameter *repl-types-to-test* '(:api
                                      ;; FIXME: Uncomment when :impl tests are passing.
@@ -33,21 +33,26 @@
             "~A" (get-output-stream-string out))))))
 
 (test examples-internally
-  (unless  (uiop:getenv "ON_CI_SERVER")
+  (unless (uiop:getenv "ON_CI_SERVER")
     (let* ((root-dir (or *project-dir* (uiop/os:getcwd)))
            (example-dir (merge-pathnames "lurk-lib/example/" root-dir)))
-      (dolist (test-file *example-tests*)
-        (let ((merged (merge-pathnames test-file example-dir)))
-          (dolist (type *repl-types-to-test*)
-            (let ((out (make-string-output-stream)))
-              (multiple-value-bind (repl state)
-                  (repl:make-repl-and-state :type type :out out)
-                (is (not (null
-                          (handler-case
-                              ;; Return T if Lurk file is run successfully.
-                              (prog1 t
-                                (repl:run repl state merged))
-                            ;; Return NIL if an error is signaled while running.
-                            (error () nil))))
-                    "~A" (get-output-stream-string out))))))))))
+      (dolist (spec *lurk-tests*)
+        (destructuring-bind (subset test-file)
+            spec
+          (let ((subset (case subset
+                          (:core (api.impl:intern-subset 'api.impl:core-subset))
+                          (:ram (api.impl:intern-subset 'api.impl:ram-subset)))))
+            (let ((merged (merge-pathnames test-file example-dir)))
+              (dolist (type *repl-types-to-test*)
+                (let ((out (make-string-output-stream)))
+                  (multiple-value-bind (repl state)
+                      (repl:make-repl-and-state :type type :out out :subset subset)
+                    (is (not (null
+                              (handler-case
+                                  ;; Return T if Lurk file is run successfully.
+                                  (prog1 t
+                                    (repl:run repl state merged))
+                                ;; Return NIL if an error is signaled while running.
+                                (error () nil))))
+                        "~A" (get-output-stream-string out))))))))))))
 


### PR DESCRIPTION
@namin This is by no means perfect, and we can certainly refactor and improve over time. However, I think it points the way to an approach for dealing with language subsets and is probably enough to unblock you now.

I did not deal with everything, just the most essential parts. I think we should also separate the Lurk tests, and probably (at least eventually) add explicit assertions of the expected subset, in order to avoid unpleasant effects of Lurk tests accidentally running in the wrong subset.

Clearly separating the tests by subset will also be useful for documentation purposes.

Also, since I didn't have time to update how the Lurk tests are run, the new ones should be failing. (CI is indeed failing, and I assume this is why — but haven't verified so something else could be wrong.) For this to work correctly, the test code which runs the `api.ram` tests will need to explicitly provide the right subset when creating the REPL.