### PR TITLE
Replaces SBCL specific code with UIOP calls

### DIFF
--- a/tooling/repl.lisp
+++ b/tooling/repl.lisp
@@ -121,7 +121,7 @@
              (make-repl-and-state :type type :subset subset)
            (dolist (run-pathname to-run)
              (setf state (run repl state run-pathname)))
-           (uiop:quit :code 0)))
+           (uiop:quit 0)))
         (t
          (repl :cli t :type type :subset subset))))))
 
@@ -164,7 +164,7 @@
         (error (e) (format (repl-state-out state) "ERROR: ~A" e))
         (condition (c) (format (repl-state-out state) "~A" c))))
     (when cli
-      (uiop:quit :code 0))))
+      (uiop:quit 0))))
 
 (deftype meta-form () '(cons (eql !) t))
 

--- a/tooling/repl.lisp
+++ b/tooling/repl.lisp
@@ -121,7 +121,7 @@
              (make-repl-and-state :type type :subset subset)
            (dolist (run-pathname to-run)
              (setf state (run repl state run-pathname)))
-           (sb-ext:exit :code 0)))
+           (uiop:quit :code 0)))
         (t
          (repl :cli t :type type :subset subset))))))
 
@@ -164,7 +164,7 @@
         (error (e) (format (repl-state-out state) "ERROR: ~A" e))
         (condition (c) (format (repl-state-out state) "~A" c))))
     (when cli
-      (sb-ext:exit :code 0))))
+      (uiop:quit :code 0))))
 
 (deftype meta-form () '(cons (eql !) t))
 


### PR DESCRIPTION
This PR makes it so that other compilers like CCL can dump an image of Lurk