### PR TITLE
Makes the ASDF file loadable from a freshly spawned REPL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.fasl
+*.*fsl
 *~
 scratch
 bin/*.image

--- a/lurk.asd
+++ b/lurk.asd
@@ -1,4 +1,4 @@
-(defsystem "lurk"
+(asdf:defsystem "lurk"
   :description "lurk"
   :version "0.0.1"
   :author "porcuquine <porcuquine@gmail.com>"
@@ -22,14 +22,14 @@
                         ((:file "package")
                          (:file "repl")
                          (:file "example"))))
-  :in-order-to ((test-op (load-op "lurk")))
-  :perform (test-op (o c)
-		    (flet ((run-suite (suite) (symbol-call :fiveam :run! suite)))
-		      (let* ((suite-specs '((#:master-suite #:lurk)))
-                             (failed (loop for spec in suite-specs
-                                           for (name-spec package-spec) = spec
-                                           for suite = (find-symbol (string name-spec) (string package-spec))
-                                           unless (run-suite suite)
-                                             collect suite)))
-			(when failed
-			  (error "Some tests failed: ~A." failed))))))
+  :in-order-to ((asdf:test-op (asdf:load-op "lurk")))
+  :perform (asdf:test-op (o c)
+		         (flet ((run-suite (suite) (uiop:symbol-call :fiveam :run! suite)))
+		           (let* ((suite-specs '((#:master-suite #:lurk)))
+                                  (failed (loop for spec in suite-specs
+                                                for (name-spec package-spec) = spec
+                                                for suite = (find-symbol (string name-spec) (string package-spec))
+                                                unless (run-suite suite)
+                                                  collect suite)))
+			     (when failed
+			       (error "Some tests failed: ~A." failed))))))

--- a/tooling/repl.lisp
+++ b/tooling/repl.lisp
@@ -5,6 +5,7 @@
 (defparameter *prompt* "> ")
 (defparameter *default-field-order* lurk.api.impl:*default-p*)
 (defparameter *repl-type* :api)
+(defparameter *default-subset-type* 'api.impl:core-subset)
 
 (defstruct repl-state subset package env ram evaluator field-order prompt in out readtable)
 


### PR DESCRIPTION
This PR allows the `lurk.asd` file to be loaded in from `CL-USER` and for the image to be dumped from just calling

```lisp
(load "lurk.asd")
(asdf:load-system :lurk)

* (sb-ext:save-lisp-and-die #p"sbcl-compressed.image"
                            :toplevel #'lurk.tooling.repl:repl
                            :executable t
                            :COMPRESSION 1)
```
Along side #52 

this also works with CCL given the command

```lisp
? (ccl:save-application "image" :prepend-kernel t
                                :toplevel-function #'lurk.tooling.repl:repl)
```

