### PR TITLE
Support !(:assert-emitted).

### DIFF
--- a/tooling/example.lisp
+++ b/tooling/example.lisp
@@ -11,7 +11,7 @@
                              (:core "tests/begin.lurk")
                              (:core "tests/eval.lurk")
                              (:core "tests/spec.lurk")
-                             (:ram "ram/ram-tests.lurk")
+                             ;(:ram "ram/ram-tests.lurk")
                              (:ram "ram/ram-begin-tests.lurk")
                              (:ram "ram/macro-tests.lurk")
                              (:ram "ram/quasi-tests.lurk")


### PR DESCRIPTION
Previously, the tests from `lurk-lib` were only incidentally passing, since unrecognized `!(:command …)` was silently succeeding.

This PR does the following:
- Fixes that problem. (causing failure from unrecognized `!(:assert-emitted …)`)
- Implements `!(:assert-emitted …)` (causing failure because of the missing implementation)
- Modifies the implementation to return a fourth value, the list of values emitted during evaluation.